### PR TITLE
Support Delay Header from Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ npm start
 - **MOCK_FILE_PATH**: The path to the text file of random responses.
 - **MOCK_FILE_SEPERATER**: Random contents seperater. As there may be instances of line breaks or code outputs, it is not advisable to separate with line breaks.
 
+## Custom Header
+- `x-set-response-delay-ms` header can be sent from the client to delay the response by that time.
+
 ## Contributing
 
 Contributions are welcome! Please submit a pull request or create an issue to get started.

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const textRoutes = require("./openAI/text");
 const imgRoutes = require("./openAI/image");
 const embeddingRoutes = require("./openAI/embeddings");
 const { load: loadRandomContents } = require("./utils/randomContents");
+const delay = require("./utils/delay")
+
 
 const start = async () => {
   await loadRandomContents();
@@ -18,7 +20,12 @@ const start = async () => {
   app.use(imgRoutes);
   app.use(embeddingRoutes);
 
-  app.get("/", (req, res) => {
+  app.get("/", async (req, res) => {
+    const delayHeader = req.headers["x-set-response-delay-ms"]
+
+  let delayTime = parseInt(delayHeader) || 0
+
+  await delay(delayTime)
     res.send("Hello World! This is MockAI");
   });
 

--- a/openAI/chat.js
+++ b/openAI/chat.js
@@ -1,10 +1,16 @@
 const express = require("express");
 const { getRandomContents } = require("../utils/randomContents");
 const { tokenize } = require("../utils/tokenize");
+const delay = require("../utils/delay")
 
 const router = express.Router();
 
-router.post("/v1/chat/completions", (req, res) => {
+router.post("/v1/chat/completions", async (req, res) => {
+  const delayHeader = req.headers["x-set-response-delay-ms"]
+
+  let delayTime = parseInt(delayHeader) || 0
+
+  await delay(delayTime)
   const defaultMockType = process.env.MOCK_TYPE || "random";
   const {
     messages,

--- a/openAI/image.js
+++ b/openAI/image.js
@@ -1,8 +1,14 @@
 const express = require("express");
+const delay = require("../utils/delay")
 
 const router = express.Router();
 
-router.post("/v1/images/generations", (req, res) => {
+router.post("/v1/images/generations", async (req, res) => {
+  const delayHeader = req.headers["x-set-response-delay-ms"]
+
+  let delayTime = parseInt(delayHeader) || 0
+
+  await delay(delayTime)
   const { prompt, n } = req.body;
 
   // Check if 'prompt' is provided and is an array

--- a/openAI/text.js
+++ b/openAI/text.js
@@ -1,10 +1,17 @@
 const express = require("express");
 const { getRandomContents } = require("../utils/randomContents");
 const { tokenize } = require("../utils/tokenize");
+const delay = require("../utils/delay")
+
 
 const router = express.Router();
 
-router.post("/v1/completions", (req, res) => {
+router.post("/v1/completions", async (req, res) => {
+  const delayHeader = req.headers["x-set-response-delay-ms"]
+
+  let delayTime = parseInt(delayHeader) || 0
+
+  await delay(delayTime)
   const defaultMockType = process.env.MOCK_TYPE || "random";
   const {
     model,

--- a/utils/delay.js
+++ b/utils/delay.js
@@ -1,0 +1,9 @@
+const delay = (delayTime)=>{
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolve();
+        }, delayTime);
+    });
+}
+
+module.exports = delay;


### PR DESCRIPTION
Fixes #3 
This PR allows you to add the header `x-set-response-delay-ms` to your requests and the server will inject that delay to the responses