### PR TITLE
Allow environment variable to adjust the json request-body limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ const start = async () => {
   await loadRandomContents();
 
   const port = process.env.SERVER_PORT || 5001;
-  app.use(express.json());
+  const req_limit = process.env.REQUEST_SIZE_LIMIT || "10kb";
+  app.use(express.json({"limit": req_limit}));
   app.use(chatRoutes);
   app.use(textRoutes);
   app.use(imgRoutes);


### PR DESCRIPTION
Set env var `REQUEST_SIZE_LIMIT` to raise or lower the maximum size of json input. 

Resolves https://github.com/polly3d/mockai/issues/14